### PR TITLE
Create CVE-2020-16846.md

### DIFF
--- a/cve/2020/16xxx/CVE-2020-16846.md
+++ b/cve/2020/16xxx/CVE-2020-16846.md
@@ -1,0 +1,5 @@
+---
+id: CVE-2020-16846
+pocs:
+    - https://github.com/vulhub/vulhub/tree/master/saltstack/CVE-2020-16846
+---


### PR DESCRIPTION
SaltStack shell injection CVE-2020-16846 POC, reference to [Vulhub](https://github.com/vulhub/vulhub/tree/master/saltstack/CVE-2020-16846)